### PR TITLE
us-68 Adding a new resource via a URL should automatically select the system default browser.

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,0 @@
-#Build Number for ANT. Do not edit!
-#Thu Feb 11 07:31:33 MST 2016
-build.number=52

--- a/src/net/sf/memoranda/ui/ResourcesPanel.java
+++ b/src/net/sf/memoranda/ui/ResourcesPanel.java
@@ -226,8 +226,6 @@ public class ResourcesPanel extends JPanel {
                         "The provided internet address could not be used.\nPlease be sure to include the http:// or https:// in your address.");
                 return;
             }
-            if (!Util.checkBrowser())
-                return;
             CurrentProject.getResourcesList().addResource(dlg.urlField.getText(), true, false);
             resourcesTable.tableChanged();
         }


### PR DESCRIPTION
Select "Resources". Add a new resource. Give a valid URL (e.g http://google.com). Observe.

The URL should be added to the resources tab without the user being prompted to select a browser. Double clicking the resource should open the default system browser.

Removed build.number from tracking.
