### PR TITLE
Actually remove build.number from tracking

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,0 @@
-#Build Number for ANT. Do not edit!
-#Thu Feb 11 07:31:33 MST 2016
-build.number=52


### PR DESCRIPTION
The other commit which added `build.number` to the gitignore didn't actually remove the file from track: this does.
